### PR TITLE
point to framework bundle

### DIFF
--- a/Classes/ios/components/MBDebugPanelSimpleComponent.m
+++ b/Classes/ios/components/MBDebugPanelSimpleComponent.m
@@ -68,7 +68,7 @@
 
 -(UINib*)cellNib_
 {
-    return [UINib nibWithNibName:[self cellClassName] bundle:nil];
+    return [UINib nibWithNibName:[self cellClassName] bundle:[NSBundle bundleForClass:[MBDebugPanel class]]];
 }
 
 -(void)bindToReusableCell:(UITableViewCell*)cell


### PR DESCRIPTION
When you are loading a pod resource and using "use_framework!" in your podfile, you must point to the framework resource bundle.

https://github.com/CocoaPods/CocoaPods/issues/2408