### PR TITLE
Bump Version number

### DIFF
--- a/MBDebugPanel.podspec
+++ b/MBDebugPanel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MBDebugPanel"
-  s.version          = "0.2.1"
+  s.version          = "0.2.2"
   s.summary          = "A painless, configurable, hidden panel to add shortcuts to run code, test features, or whatever you like."
   s.description      = <<-DESC
                        MBDebugPanel offers a simple way to embed a set of dev-mode-only features 


### PR DESCRIPTION
We need access to some code thats newer than 0.2.1 so I’m bumping the
version number on the podspec to correspond to the 0.2.2 release tag